### PR TITLE
Fix CoinGecko fetch interval and clean optional imports

### DIFF
--- a/crypto_trading_app.py
+++ b/crypto_trading_app.py
@@ -8,10 +8,6 @@ import requests
 import pandas as pd
 import numpy as np
 
-# Optional ML imports (used only when training is invoked)
-from sklearn.model_selection import TimeSeriesSplit
-from xgboost import XGBClassifier
-
 # ---------- Basic CoinGecko fetch with simple retry ----------
 
 def fetch_market_chart(coin_id: str, vs_currency: str = "usd", days: Any = 90, interval: str = "hourly") -> Dict[str, Any]:
@@ -21,7 +17,7 @@ def fetch_market_chart(coin_id: str, vs_currency: str = "usd", days: Any = 90, i
     Returns dict with 'prices' and 'total_volumes' arrays: [[ms, value], ...]
     """
     base = "https://api.coingecko.com/api/v3"
-    url = f"{base}/coins/{coin_id}/market_chart?vs_currency={vs_currency}&days={days}"
+    url = f"{base}/coins/{coin_id}/market_chart?vs_currency={vs_currency}&days={days}&interval={interval}"
     sess = requests.Session()
     for attempt in range(3):
         r = sess.get(url, timeout=30)

--- a/tests/test_fetch_market_chart.py
+++ b/tests/test_fetch_market_chart.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import crypto_trading_app as cta
+
+
+def test_fetch_market_chart_includes_interval_parameter():
+    with patch('requests.Session.get') as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        mock_get.return_value = mock_resp
+
+        cta.fetch_market_chart('bitcoin', vs_currency='usd', days=1, interval='daily')
+        args, kwargs = mock_get.call_args
+        assert 'interval=daily' in args[0]


### PR DESCRIPTION
## Summary
- include interval parameter when fetching market data
- remove heavy ML imports from module load
- add test to confirm interval is passed to CoinGecko API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0bd41058c832eaf2d82570f754734