### PR TITLE
fix: add FET mapping with ASI fallback and adapt XGBoost early stopping

### DIFF
--- a/training_utils.py
+++ b/training_utils.py
@@ -337,7 +337,12 @@ def train_symbol(symbol: str, cfg: TrainConfig) -> Dict[str, str]:
     es_split = int(len(X_train) * 0.85)
     X_t, X_v = X_train[:es_split], X_train[es_split:]
     y_t, y_v = y_train[:es_split], y_train[es_split:]
-    clf.fit(X_t, y_t, eval_set=[(X_v, y_v)], verbose=False, early_stopping_rounds=50)
+    fit_params = dict(eval_set=[(X_v, y_v)], verbose=False)
+    if "early_stopping_rounds" in XGBClassifier.fit.__code__.co_varnames:
+        fit_params["early_stopping_rounds"] = 50
+    else:
+        clf.set_params(early_stopping_rounds=50)
+    clf.fit(X_t, y_t, **fit_params)
 
     y_prob = clf.predict_proba(X_test)[:,1]
     try:


### PR DESCRIPTION
## Summary
- support Fetch.ai (FET) coin ID in analysis utils
- fallback to FET prices when ASI data is insufficient
- handle XGBoost early stopping differences across versions

## Testing
- `python -m py_compile analysis_utils.py`
- `python -m py_compile training_utils.py`
- `python - <<'PY'
from analysis_utils import fetch_ohlc
print(fetch_ohlc('FET').head())
print('FET rows', len(fetch_ohlc('FET')))
print('ASI rows', len(fetch_ohlc('ASI')))
PY`
- `python - <<'PY'
from training_utils import train_symbol, TrainConfig
cfg = TrainConfig(lookback_days=260)
res = train_symbol('BTC', cfg)
print(res.get('status'), res.get('auc'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb4e7d84832e8f1d96f39e4cb78d